### PR TITLE
Ignore desired_capacity change

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,7 @@ resource "aws_autoscaling_group" "this" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = ["desired_capacity"]
   }
 }
 


### PR DESCRIPTION
That way autoscale groups can scale without terraform ruining it,